### PR TITLE
fix workflow glob pattern

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: test
 on:
   push:
     paths:
-      - '*.ipynb'
-      - '*.yml'
-      - '*.yaml'
-      - '*.py'
+      - '**/*.ipynb'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '**/*.py'
 
 defaults:
   run:


### PR DESCRIPTION
fixed issue where CI was not run because the triggering file glob patterns were only looking in the root directory